### PR TITLE
fix: make qr modal use light theme

### DIFF
--- a/src/components/Modal.module.css
+++ b/src/components/Modal.module.css
@@ -1,6 +1,17 @@
 .panel {
+  border: 1px solid;
+  border-color: var(--color-border);
   background-color: var(--color-background);
-  border: 1px solid var(--color-border);
+
+  &[data-theme='dark'] {
+    background-color: var(--color-background-dark);
+    border-color: var(--color-border-dark);
+  }
+  &[data-theme='light'] {
+    background-color: var(--color-background-light);
+    border-color: var(--color-border-light);
+  }
+
   border-radius: 6px;
   overflow: visible;
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,9 +7,10 @@ type Props = {
   open: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  theme?: 'light' | 'dark';
 };
 
-const Modal = ({ children, open, onClose }: Props) => {
+const Modal = ({ children, open, onClose, theme }: Props) => {
   const [closing, setClosing] = useState(false);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
@@ -65,20 +66,21 @@ const Modal = ({ children, open, onClose }: Props) => {
   return (
     <dialog
       ref={dialogRef}
-      onCancel={(event: React.SyntheticEvent<HTMLDialogElement>) => {
+      onCancel={(event) => {
         event.preventDefault();
         close();
       }}
       className={classNames(ModalCSS.panel, {
         [ModalCSS.closing || '']: closing,
       })}
+      data-theme={theme}
     >
       <button
         onClick={close}
         className="x-btn"
         id={ModalCSS.btn}
         aria-label="Close modal"
-      ></button>
+      />
       {children}
     </dialog>
   );

--- a/src/components/QRCodeModal.tsx
+++ b/src/components/QRCodeModal.tsx
@@ -11,7 +11,7 @@ const QRCodeModal = () => {
   const bgColor = rootStyle.getPropertyValue('--color-background').trim();
 
   return (
-    <Modal open={isOpen} onClose={closeQRCodeModal}>
+    <Modal open={isOpen} onClose={closeQRCodeModal} theme='light'>
       <h2 className="sr-only">QR Code Modal</h2>
       <QRCodeCanvas
         value={message}

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,14 @@
   --a600: clamp(0.6rem, 6.2vw + 0.1rem, 1.953rem);
   --a700: clamp(0.6rem, 7.6vw + 0.2rem, 2.441rem);
   --a800: clamp(0.6rem, 8.2vw + 0.1rem, 3.052rem);
+
+  --color-border-light: hsl(0, 0%, 75%);
+  --color-background-light: hsl(0, 0%, 98%);
+  --color-text-light: rgba(0, 0, 0, 0.9);
+
+  --color-border-dark: hsl(0, 0%, 25%);
+  --color-background-dark: hsl(0, 0%, 2%);
+  --color-text-dark: rgba(255, 255, 255, 1);
 }
 
 .dark-theme {
@@ -30,10 +38,10 @@
   --color-transparent-high: rgba(255, 255, 255, 0.15);
   --color-transparent-veryHigh: rgba(255, 255, 255, 0.3);
 
-  --color-border: hsl(0, 0%, 25%);
-  --color-background: hsl(0, 0%, 2%);
+  --color-border: var(--color-border-dark);
+  --color-background: var(--color-background-dark);
 
-  --color-text: rgba(255, 255, 255, 1);
+  --color-text: var(--color-text-dark);
 }
 
 .light-theme {
@@ -52,10 +60,10 @@
   --color-transparent-high: rgba(0, 0, 0, 0.15);
   --color-transparent-veryHigh: rgba(0, 0, 0, 0.3);
 
-  --color-border: hsl(0, 0%, 75%);
-  --color-background: hsl(0, 0%, 98%);
+  --color-border: var(--color-border-light);
+  --color-background: var(--color-background-light);
 
-  --color-text: rgba(0, 0, 0, 0.9);
+  --color-text: var(--color-text-light);
 }
 
 body {


### PR DESCRIPTION
QR codes need to have the same surrounding colour as their background otherwise readers often cannot tell where the code ends and begins.